### PR TITLE
修改章节/附录label显示问题

### DIFF
--- a/layouts/appendix.typ
+++ b/layouts/appendix.typ
@@ -1,5 +1,5 @@
 #import "../utils/header.typ": appendix-page-header
-#import "../utils/heading.typ": appendix-first-heading, other-heading
+#import "../utils/heading.typ": appendix-first-heading, appendix-numbering, other-heading
 #import "@preview/i-figured:0.2.4"
 #import "@preview/numbly:0.1.0": numbly
 #import "@preview/equate:0.3.2": equate
@@ -41,7 +41,7 @@
       return it
     }
     let f = it.element.func()
-    let h1 = counter(heading.where(level: 1, supplement: [附录]).before(it.target)).get().first()
+    let h1 = counter(heading.where(level: 1, numbering: appendix-numbering(doctype)).before(it.target)).get().first()
     let main-h1 = counter(heading.where(level: 1).before(it.target)).get().first()
     let h1-last = query(heading.where().before(it.target)).last()
     if f == math.equation {
@@ -52,7 +52,7 @@
         it.target,
         it.element.supplement
           + [ ]
-          + if h1-last.supplement == [附录] {
+          + if h1-last.numbering == appendix-numbering(doctype) {
             equation-label(heading-index, equation-index)
           } else {
             mainmatter-equation-label(heading-index, equation-index)
@@ -67,7 +67,7 @@
         it.target,
         it.element.supplement
           + [ ]
-          + if h1-last.supplement == [附录] {
+          + if h1-last.numbering == appendix-numbering(doctype) {
             equation-label(heading-index, equation-index)
           } else {
             mainmatter-equation-label(heading-index, equation-index)

--- a/layouts/doc.typ
+++ b/layouts/doc.typ
@@ -34,6 +34,8 @@
   set par(leading: 20pt, first-line-indent: (amount: 2em, all: true))
   show: show-cn-fakebold
 
+  show heading.where(level: 1): set heading(supplement: none)
+
   show figure: set align(center)
   show table: set align(center)
   show figure.caption: set par(leading: 10pt, justify: false)

--- a/layouts/mainmatter.typ
+++ b/layouts/mainmatter.typ
@@ -4,7 +4,7 @@
 #import "@preview/equate:0.3.2": *
 #import "../utils/style.typ": zihao, ziti
 #import "../utils/header.typ": main-text-page-header
-#import "../utils/heading.typ": main-text-first-heading, other-heading
+#import "../utils/heading.typ": appendix-numbering, main-text-first-heading, other-heading
 #import "../utils/figurex.typ": preset
 
 #let mainmatter(
@@ -73,7 +73,7 @@
         it.target,
         it.element.supplement
           + [ ]
-          + if h1.supplement == [附录] {
+          + if h1.numbering == appendix-numbering(doctype) {
             appendix-equation-label(heading-index, equation-index)
           } else {
             equation-label(heading-index, equation-index)
@@ -87,7 +87,7 @@
         it.target,
         it.element.supplement
           + [ ]
-          + if h1.supplement == [附录] {
+          + if h1.numbering == appendix-numbering(doctype) {
             appendix-equation-label(heading-index, equation-index)
           } else {
             equation-label(heading-index, equation-index)

--- a/pages/outline.typ
+++ b/pages/outline.typ
@@ -1,4 +1,5 @@
 #import "../utils/style.typ": ziti, zihao
+#import "../utils/heading.typ": appendix-numbering
 #import "@preview/i-figured:0.2.4"
 
 #let outline-page(
@@ -20,7 +21,7 @@
 
   show outline.entry.where(level: 1): it => link(
     it.element.location(),
-    if doctype == "bachelor" and it.element.supplement == [附录] {
+    if doctype == "bachelor" and it.element.numbering == appendix-numbering(doctype) {
       it.indented(
         none,
         [

--- a/utils/heading.typ
+++ b/utils/heading.typ
@@ -1,10 +1,39 @@
 #import "style.typ": zihao, ziti
 #import "@preview/numbly:0.1.0": numbly
 
+#let chapter-numbering(doctype) = {
+  numbly(
+    if doctype == "bachelor" {
+      "第{1:一}章 "
+    } else { "第{1}章 " },
+    "{1}.{2} ",
+    "{1}.{2}.{3} ",
+    "{1}.{2}.{3}.{4} ",
+  )
+}
+
+#let appendix-numbering(doctype) = {
+  if doctype == "bachelor" {
+    numbly(
+      "附录{1} ",
+      "{1}.{2} ",
+      "{1}.{2}.{3} ",
+      "{1}.{2}.{3}.{4} ",
+    )
+  } else {
+    numbly(
+      "附录{1:A} ",
+      "{1:A}.{2} ",
+      "{1:A}.{2}.{3} ",
+      "{1:A}.{2}.{3}.{4} ",
+    )
+  }
+}
+
 #let no-numbering-first-heading(body) = {
   show heading.where(level: 1): set align(center)
   show heading: set par(justify: false)
-  set heading(numbering: none, supplement: auto)
+  set heading(numbering: none)
   show heading.where(level: 1): it => {
     set text(
       // 数字用 Times Roman，中文用黑体，均为四号字，加粗
@@ -33,14 +62,7 @@
 ) = {
   show heading.where(level: 1): set align(center)
   set heading(
-    numbering: numbly(
-      if doctype == "bachelor" {
-        "第{1:一}章 "
-      } else { "第{1}章 " },
-      "{1}.{2} ",
-      "{1}.{2}.{3} ",
-      "{1}.{2}.{3}.{4} ",
-    ),
+    numbering: chapter-numbering(doctype),
   )
   show heading.where(level: 1): it => {
     set text(
@@ -76,22 +98,7 @@
 ) = {
   show heading.where(level: 1): set align(center)
   set heading(
-    numbering: if doctype == "bachelor" {
-      numbly(
-        "附录{1} ",
-        "{1}.{2} ",
-        "{1}.{2}.{3} ",
-        "{1}.{2}.{3}.{4} ",
-      )
-    } else {
-      numbly(
-        "附录{1:A} ",
-        "{1:A}.{2} ",
-        "{1:A}.{2}.{3} ",
-        "{1:A}.{2}.{3}.{4} ",
-      )
-    },
-    supplement: [附录],
+    numbering: appendix-numbering(doctype),
   )
   counter(heading).update(0)
   show heading.where(level: 1): it => {


### PR DESCRIPTION
在文章中使用章节/附录label时，章节/附录字样会出现两遍，如图1，2所示。
<img width="1562" height="261" alt="demo-chapter-supplement" src="https://github.com/user-attachments/assets/1638d7da-4821-4081-a2e2-2702c77fb925" />
图1 章节label问题

<img width="1558" height="210" alt="demo-appendix-supplement" src="https://github.com/user-attachments/assets/294f4174-3788-435d-b60d-12ba2fe41b92" />
图2 附录label问题

经检查，发现是由于使用`@label`命令时，章节/附录标题的`supplement`和`numbering`都会出现一遍，造成了重复的情况。由于章节/附录字样必须出现在标题前缀中，故`numbering`参数中的字样是不能省的，那就只能把`supplement`砍成`none`了。以上可以仅对于`level:1`的标题生效，因为二级以下标题没有上述问题。

然而，审查代码时令我大跌眼镜的事情发生了，`mainmatter.typ`和`appendix.typ`中，`equate.label`的条件判断中大量出现了用`supplement`参数判断标题是否为附录的表达式。为了尽可能保留这些逻辑，我又将其替换为检查`numbering`参数是否为附录对应的自定义参数`appendix-numbering`。

修改后的效果如图3，4，`thesis.typ`编译器无报错，章节/附录的label正常显示。
<img width="1559" height="235" alt="fixed-chapter-supplement" src="https://github.com/user-attachments/assets/71d07d2f-6bef-4793-bdd0-fd8d54d19130" />
图3 修改后的章节label

<img width="1564" height="268" alt="fixed-appendix-supplement" src="https://github.com/user-attachments/assets/d2ab89d7-9a44-4102-a0e5-9b00f567fd70" />
图4 修改后的附录label

以上